### PR TITLE
Add critical range

### DIFF
--- a/tests/calculate_dpr.test.ts
+++ b/tests/calculate_dpr.test.ts
@@ -54,7 +54,47 @@ describe('calculate_dpr', () => {
       false, // advantage on dice rolls
       true   // disadvantage on dice rolls
     );
-    const correct = 1.07625; // (1-0.6975)*3.5 + 0.0025*7
+    const correct = 1.0675; // (1 - 0.6975 - 0.0025)*3.5 + 0.0025*7
+    expect(result).toBeCloseTo(correct);
+  });
+
+  it('fist (+0) on skin (AC10), crit on 18+', () => {
+    const result = calculate_dpr(
+      1,     // # attacks
+      0,     // to-hit
+      "1d6", // attack damage
+      "",    // extra per-hit damage
+      "",    // extra per-turn damage
+      "",    // extra to-hit per-hit
+      "",    // extra to-hit per-turn
+      "10",  // challenge ac
+      false, // min damage on dice rolls
+      false, // max damage on dice rolls
+      false, // advantage on dice rolls
+      false, // disadvantage on dice rolls
+      18     // minimum crit roll
+    );
+    const correct = 2.45;
+    expect(result).toBe(correct);
+  });
+
+  it('fist (+0) on skin (AC10), crit on 18+, advantage', () => {
+    const result = calculate_dpr(
+      1,     // # attacks
+      0,     // to-hit
+      "1d6", // attack damage
+      "",    // extra per-hit damage
+      "",    // extra per-turn damage
+      "",    // extra to-hit per-hit
+      "",    // extra to-hit per-turn
+      "10",  // challenge ac
+      false, // min damage on dice rolls
+      false, // max damage on dice rolls
+      true,  // advantage on dice rolls
+      false, // disadvantage on dice rolls
+      18     // minimum crit roll
+    );
+    const correct = 3.7625; // (1-0.2025-0.2775)*3.5 + 0.2775*7
     expect(result).toBeCloseTo(correct);
   });
 

--- a/tests/calculate_to_crit.test.ts
+++ b/tests/calculate_to_crit.test.ts
@@ -18,4 +18,31 @@ describe('calculate_to_crit', () => {
     const correct = 0.0025;
     expect(result).toBeCloseTo(correct, 2);
   });
+
+  it('should handle crits of 18, 19', () => {
+    let result = calculate_to_crit(false, false, 18);
+    let correct = 0.15;
+    expect(result).toBeCloseTo(correct, 2);
+    result = calculate_to_crit(false, false, 19);
+    correct = 0.1;
+    expect(result).toBeCloseTo(correct, 2);
+  });
+
+  it('should handle advantage with critical ranges', () => {
+    let result = calculate_to_crit(true, false, 18);
+    let correct = 0.2775;
+    expect(result).toBeCloseTo(correct, 2);
+    result = calculate_to_crit(true, false, 19);
+    correct = 0.19;
+    expect(result).toBeCloseTo(correct, 2);
+  });
+
+  it('should handle disadvantage with critical ranges', () => {
+    let result = calculate_to_crit(false, true, 18);
+    let correct = 0.0225;
+    expect(result).toBeCloseTo(correct, 2);
+    result = calculate_to_crit(false, true, 19);
+    correct = 0.01;
+    expect(result).toBeCloseTo(correct, 2);
+  });
 });

--- a/tests/calculate_to_hit.test.ts
+++ b/tests/calculate_to_hit.test.ts
@@ -24,12 +24,33 @@ describe('calculate_to_hit', () => {
   it('should handle advantage correctly', () => {
     const result = calculate_to_hit(0, 0, 0, 10, true, false);
     const correct = 0.70;
-    expect(result).toBe(correct);
+    expect(result).toBeCloseTo(correct, 10);
   });
   
   it('should handle disadvantage correctly', () => {
     const result = calculate_to_hit(0, 0, 0, 10, false, true);
-    const correct = 0.3025;
+    const correct = 0.30; // 1 - 0.6975 - 0.0025
     expect(result).toBeCloseTo(correct, 4);
+  });
+
+  it('should handle critical ranges correctly', () => {
+    let result = calculate_to_hit(0, 0, 0, 10, false, false, 19);
+    let correct = 0.45;
+    expect(result).toBeCloseTo(correct);
+    result = calculate_to_hit(0, 0, 0, 10, false, false, 18);
+    correct = 0.40;
+    expect(result).toBe(correct);
+  });
+
+  it('should handle critical ranges with advantage', () => {
+    const result = calculate_to_hit(0, 0, 0, 10, true, false, 19);
+    const correct = 0.6075;
+    expect(result).toBeCloseTo(correct, 10);
+  });
+
+  it('should handle critical ranges with disadvantage', () => {
+    const result = calculate_to_hit(0, 0, 0, 10, false, true, 18);
+    const correct = 0.28;
+    expect(result).toBe(correct);
   });
 });


### PR DESCRIPTION
Solves #3 

Adds `min_crit` to `calculate_dpr`, `calculate_to_hit`, and `calculate_to_crit` - the latter two are what drive the damage output in the formermost method.

Adds corresponding tests also.