### PR TITLE
Simplify parseDamage

### DIFF
--- a/Code.ts
+++ b/Code.ts
@@ -14,7 +14,7 @@ export const parseDamage = (input, critical, min_only = false, max_only = false)
     input = input.split("==");
     input = input[input.length - 1];
   }
-  const diceRegex = /(^|[+-/\*^ ])\s*(\d+)d?(\d*)(?:$|\s)/gm;
+  const diceRegex = /(^|[+-/\*^ ])\s*(\d+)d?(\d*)/gm;
   while (match = diceRegex.exec(input)) {
     const operator = match[1];
     let value = parseInt(match[2]);
@@ -23,7 +23,7 @@ export const parseDamage = (input, critical, min_only = false, max_only = false)
       const damage = (min_only ? 1 : max_only ? sides : (sides + 1) / 2);
       value = (critical ? 2 * value : value) * damage;
     }
-    if (! operator || operator === "+" || operator === " ") {
+    if ((! operator && match[3]) || operator === "+" || operator === " ") {
       roll += value;
     }
     else if (operator === "-") {

--- a/Code.ts
+++ b/Code.ts
@@ -14,7 +14,7 @@ export const parseDamage = (input, critical, min_only = false, max_only = false)
     input = input.split("==");
     input = input[input.length - 1];
   }
-  const diceRegex = /(^|[+-/\*^])\s*(\d+)d?(\d*)(?:$|\s)/gm;
+  const diceRegex = /(^|[+-/\*^ ])\s*(\d+)d?(\d*)(?:$|\s)/gm;
   while (match = diceRegex.exec(input)) {
     const operator = match[1];
     let value = parseInt(match[2]);
@@ -23,7 +23,7 @@ export const parseDamage = (input, critical, min_only = false, max_only = false)
       const damage = (min_only ? 1 : max_only ? sides : (sides + 1) / 2);
       value = (critical ? 2 * value : value) * damage;
     }
-    if (! operator || operator === "+") {
+    if (! operator || operator === "+" || operator === " ") {
       roll += value;
     }
     else if (operator === "-") {

--- a/Code.ts
+++ b/Code.ts
@@ -23,7 +23,7 @@ export const parseDamage = (input, critical, min_only = false, max_only = false)
       const damage = (min_only ? 1 : max_only ? sides : (sides + 1) / 2);
       value = (critical ? 2 * value : value) * damage;
     }
-    if ((! operator && match[3]) || operator === "+" || operator === " ") {
+    if ((! operator && match[3]) || operator === "+" || (operator === " " && match[3])) {
       roll += value;
     }
     else if (operator === "-") {

--- a/Code.ts
+++ b/Code.ts
@@ -17,11 +17,15 @@ export const parseDamage = (input, critical, min_only = false, max_only = false)
   const diceRegex = /(^|[+-/\*^ ])\s*(\d+)d?(\d*)/gm;
   while (match = diceRegex.exec(input)) {
     const operator = match[1];
-    let value = parseInt(match[2]);
+    let value = 0;
     if (match[3]) {
+      const count = parseInt(match[2]);
       const sides = parseInt(match[3]);
       const damage = (min_only ? 1 : max_only ? sides : (sides + 1) / 2);
-      value = (critical ? 2 * value : value) * damage;
+      value = (critical ? 2 * count : count) * damage;
+    }
+    else {
+      value = parseInt(match[2]);
     }
     if ((! operator && match[3]) || operator === "+" || (operator === " " && match[3])) {
       roll += value;

--- a/Code.ts
+++ b/Code.ts
@@ -8,24 +8,22 @@
  * @returns {number} The expected value of the damage dice.
  */
 export const parseDamage = (input, critical, min_only = false, max_only = false) => {
-  const diceRegex = /(\d+)d(\d+)/gm;
   let match;
   let roll = 0;
   if (String(input).indexOf("==") > -1) {
     input = input.split("==");
     input = input[input.length - 1];
   }
+  const diceRegex = /(^|[+-/\*^])\s*(\d+)d?(\d*)(?:$|\s)/gm;
   while (match = diceRegex.exec(input)) {
-    let count = parseInt(match[1]);
-    const sides = parseInt(match[2]);
-    const damage = (min_only ? 1 : max_only ? sides : (sides + 1) / 2);
-    roll += (critical ? 2 * count : count) * damage;
-  }
-  var modifierRegex = /([+-/\*^])\s*(\d+)($|\s)/gm;
-  while (match = modifierRegex.exec(input)) {
-    var operator = match[1];
-    var value = parseInt(match[2]);
-    if (operator === "+") {
+    const operator = match[1];
+    let value = parseInt(match[2]);
+    if (match[3]) {
+      const sides = parseInt(match[3]);
+      const damage = (min_only ? 1 : max_only ? sides : (sides + 1) / 2);
+      value = (critical ? 2 * value : value) * damage;
+    }
+    if (! operator || operator === "+") {
       roll += value;
     }
     else if (operator === "-") {

--- a/Code.ts
+++ b/Code.ts
@@ -88,11 +88,11 @@ export const calculate_to_hit = (to_hit, extra_attack_tohit, extra_turn_tohit, e
   var success_chance = 0.05 + (20 - expected_ac + to_hit + extra_attack_tohit + extra_turn_tohit) / 20;
   var failure_chance = 1.0 - success_chance;
   var crit_chance    = calculate_to_crit(advantage, disadvantage, min_crit, elven_accuracy);
-  if (advantage) {
-    return 1 - (failure_chance ** 2) - crit_chance;
-  }
-  else if (elven_accuracy) {
+  if (elven_accuracy) {
     return 1 - (failure_chance ** 3) - crit_chance;
+  }
+  else if (advantage) {
+    return 1 - (failure_chance ** 2) - crit_chance;
   }
   else if (disadvantage) {
     return success_chance**2 - crit_chance;

--- a/tests/calculate_dpr.test.ts
+++ b/tests/calculate_dpr.test.ts
@@ -261,4 +261,50 @@ describe('calculate_dpr', () => {
     const correct = 278.325;
     expect(result).toBe(correct);
   });
+
+  it('complex: lvl5 sorlock scorching ray/quickened eldritch blast', () => {
+    const result = calculate_dpr(
+      3,     // # attacks
+      7,     // to-hit
+      "2d6",
+      "hex 1d6 sneak attack 2d6",
+      `2x eldritch blast 2d10 + 6
+       extra hex/beam 2d6
+       extra sneak attacks 4d6
+      `,    // extra to-hit per-turn
+      "",
+      "",
+      "15",  // challenge ac
+      false, // min damage on dice rolls
+      false, // max damage on dice rolls
+      false, // advantage on dice rolls
+      false  // disadvantage on dice rolls
+    );
+    const correct = 63.05;
+    expect(result).toBe(correct);
+  });
+
+  it('complex: DAN\'s ridiculous 7x crossbow barrage', () => {
+    const result = calculate_dpr(
+      7,     // # attacks
+      12,     // to-hit
+      "1d6 + 6",
+      `poison xbow   1d4
+       necrotic bolt 1d6
+       crimson rite  1d4
+       sharpshooter +10`,
+      `favored foe      1d4
+       bonus attack dmg 1d8
+       sneak attack     3d6`,
+      "",
+      "",
+      "19",  // challenge ac
+      false, // min damage on dice rolls
+      false, // max damage on dice rolls
+      false, // advantage on dice rolls
+      false  // disadvantage on dice rolls
+    );
+    const correct = 154.525;
+    expect(result).toBeCloseTo(correct);
+  });
 });

--- a/tests/calculate_dpr.test.ts
+++ b/tests/calculate_dpr.test.ts
@@ -268,7 +268,7 @@ describe('calculate_dpr', () => {
       7,     // to-hit
       "2d6",
       "hex 1d6 sneak attack 2d6",
-      `2x eldritch blast 2d10 + 6
+      `2 eldritch blasts 2d10+6
        extra hex/beam 2d6
        extra sneak attacks 4d6
       `,    // extra to-hit per-turn

--- a/tests/calculate_dpr.test.ts
+++ b/tests/calculate_dpr.test.ts
@@ -242,4 +242,23 @@ describe('calculate_dpr', () => {
       expect(result).toBeCloseTo(correct);
     }
   });
+
+  it('complex: bruce vilanch 12x attack', () => {
+    const result = calculate_dpr(
+      12,     // # attacks
+      14,     // to-hit
+      "1d6 + 3d6 + 10",
+      "large sized weapons 1d6",
+      "enlarged extra 1d8",
+      "",    // extra to-hit per-hit
+      "",    // extra to-hit per-turn
+      "19",  // challenge ac
+      false, // min damage on dice rolls
+      false, // max damage on dice rolls
+      false, // advantage on dice rolls
+      false  // disadvantage on dice rolls
+    );
+    const correct = 278.325;
+    expect(result).toBe(correct);
+  });
 });

--- a/tests/calculate_dpr.test.ts
+++ b/tests/calculate_dpr.test.ts
@@ -269,7 +269,7 @@ describe('calculate_dpr', () => {
       "2d6",
       "hex 1d6 sneak attack 2d6",
       `2 eldritch blasts 2d10+6
-       extra hex/beam 2d6
+       extra fake level 69 hex/beam 2d6
        extra sneak attacks 4d6
       `,    // extra to-hit per-turn
       "",


### PR DESCRIPTION
Reduces the parsing to one regex that handles both dice and constants.