### PR TITLE
Add re-rolled EV, re-rolled damage dice mechanics

### DIFF
--- a/Code.ts
+++ b/Code.ts
@@ -218,8 +218,8 @@ export const calculate_dpr = (
     minDmg,
     maxDmg,
     savageCriticals,
-    rerolledDamageDieCount,
-    rerolledDamageDieValue
+    0,
+    undefined
   );
   const perAttackBonus = parseDamage(
     extraAttackDamage,
@@ -227,8 +227,8 @@ export const calculate_dpr = (
     minDmg,
     maxDmg,
     false,
-    rerolledDamageDieCount,
-    rerolledDamageDieValue
+    0,
+    undefined
   );
   const perTurnCritBonus = parseDamage(
     extraTurnDamage,
@@ -236,8 +236,8 @@ export const calculate_dpr = (
     minDmg,
     maxDmg,
     savageCriticals,
-    rerolledDamageDieCount,
-    rerolledDamageDieValue
+    0,
+    undefined
   );
   const perTurnBonus = parseDamage(
     extraTurnDamage,
@@ -245,8 +245,8 @@ export const calculate_dpr = (
     minDmg,
     maxDmg,
     false,
-    rerolledDamageDieCount,
-    rerolledDamageDieValue
+    0,
+    undefined
   );
   const extraAttackToHit = parseDamage(
     extraAttackModifier,

--- a/Code.ts
+++ b/Code.ts
@@ -1,4 +1,27 @@
 /**
+ * Returns the value of a re-rolled die with `sides` sides.
+ *
+ * @param {number} sides - The number of sides.
+ * @param {boolean} [incremental=false] - Optional. If true, returns the difference between the rerolled and original values.
+ * @param {number} [maxReroll=sides / 2] - Optional. Specifies what the maximum value is that gets re-rolled.
+ * @param {number} [count=1] - Optional. The number of dice to re-roll.
+ * @returns {number} The expected value of the re-rolled die.
+ */
+export const getEvRerolled = (
+  sides: number,
+  incremental: boolean = false,
+  maxReroll: number = sides / 2,
+  count: number = 1
+): number => {
+  const summer = (x: number) => (x > 1 ? x + summer(x - 1) : 1);
+  const expected = (sides + 1) / 2;
+  const rerollChance = maxReroll / sides;
+  const rerolled =
+    rerollChance * expected + (1 / sides) * (summer(sides) - summer(maxReroll));
+  return count * (incremental ? rerolled - expected : rerolled);
+};
+
+/**
  * Parses a damage dice string (1d8 + 4) and returns a floating point representation.
  *
  * @param {string} input - The input value to parse.
@@ -6,6 +29,8 @@
  * @param {boolean} [minOnly=false] - Optional. If true, uses `1` in place of dice rolls.
  * @param {boolean} [maxOnly=false] - Optional. If true, uses the max roll of a dice.
  * @param {boolean} [savageCriticals=false] - Optional. If true, adds an extra damage die to criticals.
+ * @param {number} [rerolledDamageDieCount=0] - Optional. The # of damage dice to re-roll. Include critical damage dice.
+ * @param {number} [rerolledDamageDieCount=undefined] - Optional. The highest value to re-roll damage dice on.
  * @returns {number} The expected value of the damage dice.
  */
 export const parseDamage = (
@@ -13,7 +38,9 @@ export const parseDamage = (
   critical: boolean = false,
   minOnly: boolean = false,
   maxOnly: boolean = false,
-  savageCriticals: boolean = false
+  savageCriticals: boolean = false,
+  rerolledDamageDieCount: number = 0,
+  rerolledDamageDieValue: number = undefined
 ): number => {
   let match: RegExpExecArray;
   let roll = 0;
@@ -27,7 +54,14 @@ export const parseDamage = (
     if (match[3]) {
       const sides = parseInt(match[3]);
       const damage = minOnly ? 1 : maxOnly ? sides : (sides + 1) / 2;
-      value = (critical ? (savageCriticals ? 3 : 2) * count : count) * damage;
+      const diceCount = critical ? (savageCriticals ? 3 : 2) * count : count;
+      value = diceCount * damage;
+      value += getEvRerolled(
+        sides,
+        true,
+        rerolledDamageDieValue || sides / 2,
+        Math.min(diceCount, rerolledDamageDieCount)
+      );
     } else {
       value = count;
     }
@@ -136,6 +170,8 @@ export const calculateToHit = (
  * @param {number} [minCrit=20] - The minimum roll on a D20 to score a critical.
  * @param {boolean} [elvenAccuracy=false] - Optional. If true, elven accuracy is applied.
  * @param {boolean} [savageCriticals=false] - Optional. If true, adds an extra damage die to criticals.
+ * @param {number} [rerolledDamageDieCount=0] - Optional. The # of damage dice to re-roll. Include critical damage dice.
+ * @param {number} [rerolledDamageDieValue=undefined] - Optional. The highest value to re-roll damage dice on.
  * @returns {number} The given damage as described by the parameters
  */
 // eslint-disable-next-line camelcase
@@ -154,32 +190,64 @@ export const calculate_dpr = (
   disadvantage: boolean = false,
   minCrit: number = 20,
   elvenAccuracy: boolean = false,
-  savageCriticals: boolean = false
+  savageCriticals: boolean = false,
+  rerolledDamageDieCount: number = 0,
+  rerolledDamageDieValue: number = undefined
 ): number => {
   const critDamage = parseDamage(
     attackDamage,
     true,
     minDmg,
     maxDmg,
-    savageCriticals
+    savageCriticals,
+    rerolledDamageDieCount,
+    rerolledDamageDieValue
   );
-  const baseDamage = parseDamage(attackDamage, false, minDmg, maxDmg);
+  const baseDamage = parseDamage(
+    attackDamage,
+    false,
+    minDmg,
+    maxDmg,
+    false,
+    rerolledDamageDieCount,
+    rerolledDamageDieValue
+  );
   const perAttackCritBonus = parseDamage(
     extraAttackDamage,
     true,
     minDmg,
     maxDmg,
-    savageCriticals
+    savageCriticals,
+    rerolledDamageDieCount,
+    rerolledDamageDieValue
   );
-  const perAttackBonus = parseDamage(extraAttackDamage, false, minDmg, maxDmg);
+  const perAttackBonus = parseDamage(
+    extraAttackDamage,
+    false,
+    minDmg,
+    maxDmg,
+    false,
+    rerolledDamageDieCount,
+    rerolledDamageDieValue
+  );
   const perTurnCritBonus = parseDamage(
     extraTurnDamage,
     true,
     minDmg,
     maxDmg,
-    savageCriticals
+    savageCriticals,
+    rerolledDamageDieCount,
+    rerolledDamageDieValue
   );
-  const perTurnBonus = parseDamage(extraTurnDamage, false, minDmg, maxDmg);
+  const perTurnBonus = parseDamage(
+    extraTurnDamage,
+    false,
+    minDmg,
+    maxDmg,
+    false,
+    rerolledDamageDieCount,
+    rerolledDamageDieValue
+  );
   const extraAttackToHit = parseDamage(
     extraAttackModifier,
     false,

--- a/tests/calculateDpr.test.ts
+++ b/tests/calculateDpr.test.ts
@@ -1,6 +1,6 @@
 import { calculate_dpr as calculateDpr } from "../Code";
 
-describe("calculate_dpr", () => {
+describe("calculateDpr", () => {
   it("fist (+0) on skin (AC10)", () => {
     const result = calculateDpr(
       1, // # attacks
@@ -98,6 +98,55 @@ describe("calculate_dpr", () => {
       true // savage attacker/extra critical damage
     );
     const correct = 3.5 * 0.5 + 10.5 * 0.05;
+    expect(result).toBe(correct);
+  });
+
+  it("fist (+0) on skin (AC10), piercer (1 reroll)", () => {
+    const result = calculateDpr(
+      1, // # attacks
+      0, // to-hit
+      "1d6 piercing damage", // attack damage
+      "", // extra per-hit damage
+      "", // extra per-turn damage
+      "", // extra to-hit per-hit
+      "", // extra to-hit per-turn
+      "10", // challenge ac
+      false, // min damage on dice rolls
+      false, // max damage on dice rolls
+      false, // advantage on dice rolls
+      false, // disadvantage on dice rolls
+      20, // minimum crit
+      false, // elven accuracy
+      true, // savage attacker/extra critical damage
+      1, // # re-rolled dice count
+      3 // highest re-rolled face
+    );
+    const correct = 4.25 * 0.5 + (4.25 + 3.5 + 3.5) * 0.05;
+    expect(result).toBe(correct);
+  });
+
+  it("2d6 (+0) on skin (AC10), great weapon fighter (reroll < 3)", () => {
+    const result = calculateDpr(
+      1, // # attacks
+      0, // to-hit
+      "2d6 hammer fists", // attack damage
+      "", // extra per-hit damage
+      "", // extra per-turn damage
+      "", // extra to-hit per-hit
+      "", // extra to-hit per-turn
+      "10", // challenge ac
+      false, // min damage on dice rolls
+      false, // max damage on dice rolls
+      false, // advantage on dice rolls
+      false, // disadvantage on dice rolls
+      20, // minimum crit
+      false, // elven accuracy
+      false, // savage attacker/extra critical damage
+      4, // # re-rolled dice count
+      2 // highest re-rolled face
+    );
+    const ev = 2 * ((1 / 3) * 3.5 + (1 / 6) * (3 + 4 + 5 + 6));
+    const correct = 0.5 * ev + 0.05 * 2 * ev;
     expect(result).toBe(correct);
   });
 

--- a/tests/calculateSpellDamage.test.ts
+++ b/tests/calculateSpellDamage.test.ts
@@ -1,6 +1,6 @@
 import { calculateSpellDamage } from "../Code";
 
-describe("calculate_spell_damage", () => {
+describe("calculateSpellDamage", () => {
   it("calculate fireball correctly", () => {
     const result = calculateSpellDamage(15, "8d6", "", "", false, 7, 1);
     const correct = 22.4; // (0.40 * (8*3.5)/2) + (0.60 * (8*3.5))

--- a/tests/calculateToCrit.test.ts
+++ b/tests/calculateToCrit.test.ts
@@ -1,6 +1,6 @@
 import { calculateToCrit } from "../Code";
 
-describe("calculate_to_crit", () => {
+describe("calculateToCrit", () => {
   it("should return 5% for normal calls", () => {
     const result = calculateToCrit(false, false);
     const correct = 0.05;

--- a/tests/calculateToHit.test.ts
+++ b/tests/calculateToHit.test.ts
@@ -1,6 +1,6 @@
 import { calculateToHit } from "../Code";
 
-describe("calculate_to_hit", () => {
+describe("calculateToHit", () => {
   it("should return 50% for a flat DC10", () => {
     const result = calculateToHit(0, 10, false, false);
     const correct = 0.5;

--- a/tests/getEvRerolled.test.ts
+++ b/tests/getEvRerolled.test.ts
@@ -1,0 +1,65 @@
+import { getEvRerolled } from "../Code";
+
+describe("getEvRerolled", () => {
+  const dice = {
+    4: 0.5 * 2.5 + 0.25 * (3 + 4),
+    6: 0.5 * 3.5 + (1 / 6) * (4 + 5 + 6),
+    8: 0.5 * 4.5 + (1 / 8) * (5 + 6 + 7 + 8),
+    10: 0.5 * 5.5 + (1 / 10) * (6 + 7 + 8 + 9 + 10),
+    12: 0.5 * 6.5 + (1 / 12) * (7 + 8 + 9 + 10 + 11 + 12),
+    20:
+      0.5 * 10.5 + (1 / 20) * (11 + 12 + 13 + 14 + 15 + 16 + 17 + 18 + 19 + 20),
+  };
+
+  it("calculate re-rolled dice values correctly", () => {
+    for (const die in dice) {
+      const result = getEvRerolled(Number(die));
+      expect(result).toBe(dice[die]);
+    }
+  });
+
+  it("handle calculating incremental re-rolled values", () => {
+    for (const d in dice) {
+      const die = Number(d);
+      const result = getEvRerolled(die, true);
+      expect(result).toBe(dice[d] - (die + 1) / 2);
+    }
+  });
+
+  it("handle smaller re-roll ranges (e.g. 1s and 2s only, great weapon fighting)", () => {
+    const gwDice = {
+      4: (1 / 2) * 2.5 + 0.25 * (3 + 4),
+      6: (1 / 3) * 3.5 + (1 / 6) * (3 + 4 + 5 + 6),
+      8: (1 / 4) * 4.5 + (1 / 8) * (3 + 4 + 5 + 6 + 7 + 8),
+      10: (1 / 5) * 5.5 + (1 / 10) * (3 + 4 + 5 + 6 + 7 + 8 + 9 + 10),
+      12: (1 / 6) * 6.5 + (1 / 12) * (3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11 + 12),
+      20:
+        (1 / 10) * 10.5 +
+        (1 / 20) *
+          (3 +
+            4 +
+            5 +
+            6 +
+            7 +
+            8 +
+            9 +
+            10 +
+            11 +
+            12 +
+            13 +
+            14 +
+            15 +
+            16 +
+            17 +
+            18 +
+            19 +
+            20),
+    };
+
+    for (const d in gwDice) {
+      const die = Number(d);
+      const result = getEvRerolled(die, false, 2);
+      expect(result).toBe(gwDice[d]);
+    }
+  });
+});

--- a/tests/parseDamage.test.ts
+++ b/tests/parseDamage.test.ts
@@ -75,4 +75,11 @@ describe("parseDamage", () => {
     const correct = 16;
     expect(result).toBe(correct);
   });
+
+  it("should handle damage re-rolls properly", () => {
+    const damage = "1d6";
+    const result = parseDamage(damage, false, false, false, false, 1);
+    const correct = 4.25;
+    expect(result).toBe(correct);
+  });
 });


### PR DESCRIPTION
Closes #14 

* adds `getEvRerolled` which gives you the EV with re-rolling factored in.
* adds `rerolledDamageDieCount` and `rerolledDamageDieValue` to `calculate_dpr` to specify how many dice to re-roll/how low on the dice to re-roll.