### PR TITLE
add dpr calc features, misc fixes

### DIFF
--- a/tests/calculateDpr.test.ts
+++ b/tests/calculateDpr.test.ts
@@ -391,4 +391,57 @@ describe("calculateDpr", () => {
     const correct = 154.525;
     expect(result).toBeCloseTo(correct);
   });
+
+  it("damage on miss: dagger (+0) on skin (AC10)", () => {
+    const missDamage = 6;
+    const result = calculateDpr(
+      1, // # attacks
+      0, // to-hit
+      "1d4", // attack damage
+      "", // extra per-hit damage
+      "", // extra per-turn damage
+      "", // extra to-hit per-hit
+      "", // extra to-hit per-turn
+      "10", // challenge ac
+      false, // min damage on dice rolls
+      false, // max damage on dice rolls
+      false, // advantage on dice rolls
+      false, // disadvantage on dice rolls
+      20, // crit range
+      false, // elven advantage
+      0, // extra criticals
+      0, // # of damage die to reroll
+      0, // # on face to reroll,
+      0, // # to use in re-roll (doesnt matter here)
+      missDamage // damage on miss
+    );
+    const correct = 0.05 * 5 + 0.5 * 2.5 + (1 - 0.55) * missDamage;
+    expect(result).toBeCloseTo(correct, 4);
+  });
+
+  it("gwm damage re-roll: {1, 2} -> {3, 3}", () => {
+    const result = calculateDpr(
+      1, // # attacks
+      0, // to-hit
+      "1d4", // attack damage
+      "", // extra per-hit damage
+      "", // extra per-turn damage
+      "", // extra to-hit per-hit
+      "", // extra to-hit per-turn
+      "10", // challenge ac
+      false, // min damage on dice rolls
+      false, // max damage on dice rolls
+      false, // advantage on dice rolls
+      false, // disadvantage on dice rolls
+      20, // crit range
+      false, // elven advantage
+      0, // extra criticals
+      2, // # of damage die to reroll
+      2, // # on face to reroll,
+      3 // # to use in re-roll (doesnt matter here)
+    );
+    const ev = (3 + 3 + 3 + 4) / 4;
+    const correct = 0.05 * 2 * ev + 0.5 * ev;
+    expect(result).toBeCloseTo(correct, 4);
+  });
 });

--- a/tests/getEvRerolled.test.ts
+++ b/tests/getEvRerolled.test.ts
@@ -62,4 +62,22 @@ describe("getEvRerolled", () => {
       expect(result).toBe(gwDice[d]);
     }
   });
+
+  it("handle great weapon master feat (phb 2024) re-rolls: {1, 2} -> {3, 3}", () => {
+    const actual = getEvRerolled(8, false, 2, undefined, 3);
+    const expected = (3 + 3 + 3 + 4 + 5 + 6 + 7 + 8) / 8;
+    expect(actual).toBe(expected);
+  });
+
+  it("handle great weapon master feat (phb 2024) re-rolls incrementally", () => {
+    const actual = getEvRerolled(8, true, 2, undefined, 3);
+    const expected = (3 + 3 + 3 + 4 + 5 + 6 + 7 + 8) / 8 - (8 + 1) / 2;
+    expect(actual).toBe(expected);
+  });
+
+  it("handle percentage rerolls instead of whole face #s", () => {
+    const actual = getEvRerolled(8, false, 0.5);
+    const expected = (4 * 4.5 + 5 + 6 + 7 + 8) / 8;
+    expect(actual).toBe(expected);
+  });
 });

--- a/tests/parseDamage.test.ts
+++ b/tests/parseDamage.test.ts
@@ -82,4 +82,11 @@ describe("parseDamage", () => {
     const correct = 4.25;
     expect(result).toBe(correct);
   });
+
+  it("should handle great weapon master feat re-rolls", () => {
+    const damage = "1d6";
+    const result = parseDamage(damage, false, false, false, undefined, 2, 2, 3);
+    const correct = (3 + 3 + 3 + 4 + 5 + 6) / 6;
+    expect(result).toBe(correct);
+  });
 });


### PR DESCRIPTION
This PR:

* [x] adds damage on miss (solves #27), with tests
* [x] adds a specific re-roll damage value (instead of using the EV) (solves #31), with tests
* [x] adds a percentage re-roll calc (instead of a hardcoded 'reroll all below `X` value' , it'll reroll for a % of the lower faces of a die)

Misc, unrelated fixes include:
* [x] fixes a typo in a docstring variable
* [x] fixes minor logic issue in `extraCriticals` (those dice were accidentally being doubled in count)