### PR TITLE
reroll dice in other damage fields

### DIFF
--- a/src/Code.ts
+++ b/src/Code.ts
@@ -266,8 +266,9 @@ export const calculate_dpr = (
     minDmg,
     maxDmg,
     extraCriticals,
-    0,
-    undefined
+    rerolledDamageDieCount,
+    rerolledDamageDieFindValue,
+    rerolledDamageDieReplaceValue
   );
   const perAttackBonus = parseDamage(
     extraAttackDamage,
@@ -275,8 +276,9 @@ export const calculate_dpr = (
     minDmg,
     maxDmg,
     0,
-    0,
-    undefined
+    rerolledDamageDieCount,
+    rerolledDamageDieFindValue,
+    rerolledDamageDieReplaceValue
   );
   const perTurnCritBonus = parseDamage(
     extraTurnDamage,
@@ -284,8 +286,9 @@ export const calculate_dpr = (
     minDmg,
     maxDmg,
     extraCriticals,
-    0,
-    undefined
+    rerolledDamageDieCount,
+    rerolledDamageDieFindValue,
+    rerolledDamageDieReplaceValue
   );
   const perTurnBonus = parseDamage(
     extraTurnDamage,
@@ -293,8 +296,9 @@ export const calculate_dpr = (
     minDmg,
     maxDmg,
     0,
-    0,
-    undefined
+    rerolledDamageDieCount,
+    rerolledDamageDieFindValue,
+    rerolledDamageDieReplaceValue
   );
   const extraAttackToHit = parseDamage(
     extraAttackModifier,

--- a/tests/calculateDpr.test.ts
+++ b/tests/calculateDpr.test.ts
@@ -444,4 +444,28 @@ describe("calculateDpr", () => {
     const correct = 0.05 * 2 * ev + 0.5 * ev;
     expect(result).toBeCloseTo(correct, 4);
   });
+
+  it("handle damage re-roll on all damage fields", () => {
+    const result = calculateDpr(
+      1, // # attacks
+      0, // to-hit
+      "1d4", // attack damage
+      "1d4", // extra per-hit damage
+      "1d4", // extra per-turn damage
+      "", // extra to-hit per-hit
+      "", // extra to-hit per-turn
+      "10", // challenge ac
+      false, // min damage on dice rolls
+      false, // max damage on dice rolls
+      false, // advantage on dice rolls
+      false, // disadvantage on dice rolls
+      20, // crit range
+      false, // elven advantage
+      0, // extra criticals
+      100 // # of damage die to reroll
+    );
+    const ev = 3 * ((2.5 + 2.5 + 3 + 4) / 4);
+    const correct = 0.05 * 2 * ev + 0.5 * ev;
+    expect(result).toBeCloseTo(correct, 4);
+  });
 });


### PR DESCRIPTION
This PR:

* adds reroll mechanics to the other fields where damage might occur (extra damage per attack, extra damage per turn)

This likely needs some sort of centralized rerolled-dice-counting logic, because some of these mechanics only let you re-roll a single die, and that count isn't shared between the isolated damage calculations right now, so this'll overstate damage where that's the case until it's fixed up.